### PR TITLE
Add extended ID validity check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ buildscript {
 plugins {
     id "com.jfrog.bintray" version "1.8.1"
     id "org.jetbrains.kotlin.jvm" version "$kotlin_version"
+    id "org.jetbrains.dataframe.generator"
 }
 
 apply plugin: 'kotlin'

--- a/generator/build.gradle.kts
+++ b/generator/build.gradle.kts
@@ -1,0 +1,25 @@
+plugins {
+    `java-gradle-plugin`
+    `kotlin-dsl`
+}
+
+val kotlinCompilerVersion: String by project
+val kotlinPoetVersion: String by project
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(kotlin("compiler-embeddable", kotlinCompilerVersion))
+    implementation("com.squareup:kotlinpoet:$kotlinPoetVersion")
+}
+
+gradlePlugin {
+    plugins {
+        create("dependencies") {
+            id = "org.jetbrains.dataframe.generator"
+            implementationClass = "org.jetbrains.dataframe.keywords.KeywordsGeneratorPlugin"
+        }
+    }
+}

--- a/generator/gradle.properties
+++ b/generator/gradle.properties
@@ -1,0 +1,2 @@
+kotlinCompilerVersion=1.4.31
+kotlinPoetVersion=1.7.2

--- a/generator/src/main/kotlin/org/jetbrains/dataframe/keywords/EnumEntry.kt
+++ b/generator/src/main/kotlin/org/jetbrains/dataframe/keywords/EnumEntry.kt
@@ -1,0 +1,6 @@
+package org.jetbrains.dataframe.keywords
+
+data class EnumEntry(
+    val name: String,
+    val strValue: String
+)

--- a/generator/src/main/kotlin/org/jetbrains/dataframe/keywords/GeneratorTask.kt
+++ b/generator/src/main/kotlin/org/jetbrains/dataframe/keywords/GeneratorTask.kt
@@ -1,0 +1,92 @@
+package org.jetbrains.dataframe.keywords
+
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeSpec
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
+import org.jetbrains.kotlin.lexer.KtKeywordToken
+import org.jetbrains.kotlin.lexer.KtTokens
+import java.io.File
+
+open class GeneratorTask : DefaultTask() {
+
+    @OutputDirectory
+    lateinit var srcDir: File
+
+    private val taskPackageName = "org.jetbrains.dataframe.keywords"
+
+    override fun getGroup() = "codegen"
+
+    @TaskAction
+    fun generate() {
+        srcDir.deleteRecursively()
+        generateKeywordEnums()
+    }
+
+    private fun generateKeywordEnums() {
+        listOf(
+            "HardKeywords" to KtTokens.KEYWORDS,
+            "SoftKeywords" to KtTokens.SOFT_KEYWORDS,
+            "ModifierKeywords" to KtTokens.MODIFIER_KEYWORDS
+        ).forEach { (name, set) ->
+            generateKeywordsEnum(name, set)
+        }
+    }
+
+    private fun generateKeywordsEnum(name: String, tokenSet: TokenSet) {
+        buildKwEnum(name, getKeywords(tokenSet)).writeTo(srcDir)
+    }
+
+    private fun getKeywords(tokenSet: TokenSet): List<EnumEntry> {
+        fun id(value: String) = value.toUpperCase().replace("!", "NOT_")
+
+        return tokenSet.types.map { t ->
+            t as KtKeywordToken
+            EnumEntry(id(t.value), t.value)
+        }
+    }
+
+    private fun buildKwEnum(name: String, values: List<EnumEntry>): FileSpec {
+        val fileBuilder = FileSpec.builder(taskPackageName, name)
+        val valList = mutableListOf<String>()
+
+        val enumBuilder = TypeSpec.enumBuilder(name).apply {
+            primaryConstructor(
+                FunSpec.constructorBuilder()
+                    .addParameter("value", String::class)
+                    .build()
+            )
+
+            values.forEach { entry ->
+                valList.add("\"${entry.strValue}\"")
+                addEnumConstant(
+                    entry.name, TypeSpec.anonymousClassBuilder()
+                        .addSuperclassConstructorParameter("%S", entry.strValue)
+                        .build()
+                )
+            }
+
+            val compObj = TypeSpec.companionObjectBuilder().addProperty(
+                PropertySpec
+                    .builder("VALUES", List::class.parameterizedBy(String::class))
+                    .initializer(valList.joinToString(", ", "listOf(", ")"))
+                    .build()
+            ).build()
+
+            addType(compObj)
+        }
+
+        fileBuilder.addType(enumBuilder.build())
+
+        return fileBuilder.build()
+    }
+
+    companion object {
+        const val NAME = "generateKeywordsSrc"
+    }
+}

--- a/generator/src/main/kotlin/org/jetbrains/dataframe/keywords/KeywordsGeneratorPlugin.kt
+++ b/generator/src/main/kotlin/org/jetbrains/dataframe/keywords/KeywordsGeneratorPlugin.kt
@@ -1,0 +1,28 @@
+package org.jetbrains.dataframe.keywords
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.kotlin.dsl.get
+import org.gradle.kotlin.dsl.register
+import java.io.File
+
+class KeywordsGeneratorPlugin: Plugin<Project> {
+    override fun apply(target: Project): Unit = with(target){
+        val genSrcDir = buildDir.resolve("generatedSrc")
+        val sourceSets = project.extensions.getByName("sourceSets") as SourceSetContainer
+        val mainSourceSet: SourceSet = sourceSets.named("main").get()
+        mainSourceSet.addDir(genSrcDir)
+
+        val genTask = tasks.register<GeneratorTask>(GeneratorTask.NAME) {
+            srcDir = genSrcDir
+        }
+
+        tasks["compileKotlin"].dependsOn(genTask)
+    }
+
+    private fun SourceSet.addDir(dir: File) {
+        java.setSrcDirs(java.srcDirs + dir)
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,3 @@
 rootProject.name = projectName
+
+includeBuild("generator")

--- a/src/main/kotlin/org/jetbrains/dataframe/impl/codeGen/CodeGeneratorImpl.kt
+++ b/src/main/kotlin/org/jetbrains/dataframe/impl/codeGen/CodeGeneratorImpl.kt
@@ -7,6 +7,8 @@ import org.jetbrains.dataframe.columns.ColumnGroup
 import org.jetbrains.dataframe.columns.DataColumn
 import org.jetbrains.dataframe.columns.FrameColumn
 import org.jetbrains.dataframe.columns.MapColumn
+import org.jetbrains.dataframe.keywords.HardKeywords
+import org.jetbrains.dataframe.keywords.ModifierKeywords
 import org.jetbrains.dataframe.stubs.DataFrameToListNamedStub
 import org.jetbrains.dataframe.stubs.DataFrameToListTypedStub
 import org.jetbrains.kotlinx.jupyter.api.Code
@@ -148,7 +150,13 @@ class CodeGeneratorImpl : CodeGenerator {
 
     }
 
-    private fun String.quoteIfNeeded() = if(contains(charsToQuote)) "`$this`" else this
+    private fun String.needsQuoting(): Boolean {
+        return contains(charsToQuote)
+                || HardKeywords.VALUES.contains(this)
+                || ModifierKeywords.VALUES.contains(this)
+    }
+
+    private fun String.quoteIfNeeded() = if(needsQuoting()) "`$this`" else this
 
     private fun getFields(marker: KClass<*>, withBaseTypes: Boolean): Map<String, FieldInfo> {
         val result = mutableMapOf<String, FieldInfo>()
@@ -185,7 +193,7 @@ class CodeGeneratorImpl : CodeGenerator {
 
     private fun generateValidFieldName(name: String, index: Int, usedNames: Collection<String>): String {
         var result = name
-        val needsQuote = name.contains(charsToQuote)
+        val needsQuote = name.needsQuoting()
         if (needsQuote) {
             result = name.replace("<", "{")
                     .replace(">", "}")


### PR DESCRIPTION
Here we generate enums containing keywords.
We use Kotlin compiler artifact as a source of keywords and kotlinpoet library for generation.

Note that dataframe artifact remains leightweight after all, only several enums are added to it, and no additional production dependencies.